### PR TITLE
Fix when the mongoose connection already exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,20 @@ function Seeder() {
 
 Seeder.prototype.connect = function(db, cb) {
 	var _this = this;
+	/*
+		switch (mongoose.connection.readyState) {
+			case 0 : Disconnected;
+			case 1 : Connected;
+			case 2 : Connecting;
+			case 3 : Disconnecting;
+		}
+		source http://mongoosejs.com/docs/api.html#connection_Connection-readyState
+	*/
+	if (mongoose.connection.readyState == 1) {
+		_this.connected = true;
+		console.log('Successfully initialized mongoose-seed');
+		cb();
+	}
 	mongoose.connect(db, function(err) {
 		// Log Error
 		if (err) {


### PR DESCRIPTION
I have a route which I use for seeding the database. However as I'm using express and the whole app is designed in such a way that the mongoose connection happens on startup. So when I try to seed, I get a connection error "Error: Trying to open unclosed connection.". 
In the following fix, I don't attempt to connect if the connection is already established.
Please review and accept the pull-request as I would need the updates on npm too.
