### PR TITLE
Callback invoked only when all entries have been processed

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,22 +122,27 @@ Seeder.prototype.populateModels = function(seedData, cb) {
 			return;
 		}
 
+		var totalEntries = 0;
+		var processedEntries = 0;
 		// Populate each model
 		seedData.forEach(function(entry) {
 			var Model = mongoose.model(entry.model);
+			totalEntries += entry.documents.length;
 			entry.documents.forEach(function(document, j) {
 				Model.create(document, function(err) {
 					if (err) {
 						console.error(chalk.red('Error creating document [' + j + '] of ' + entry.model + ' model'));
 						console.error(chalk.red('Error: ' + err.message));
-						return;
+					} else {
+						console.log('Successfully created document [' + j + '] of ' + entry.model + ' model');
 					}
-					console.log('Successfully created document [' + j + '] of ' + entry.model + ' model');
+					if (++processedEntries == totalEntries) {
+						cb();
+					}
 				});
 			});
 		});
 	});
-	cb();
 };
 
 module.exports = new Seeder();

--- a/index.js
+++ b/index.js
@@ -122,13 +122,10 @@ Seeder.prototype.populateModels = function(seedData, cb) {
 			return;
 		}
 
-		var totalEntries = 0;
-		var processedEntries = 0;
 		// Populate each model
-		seedData.forEach(function(entry) {
+		async.eachOf(seedData, function(entry, i, outerCallback) {
 			var Model = mongoose.model(entry.model);
-			totalEntries += entry.documents.length;
-			entry.documents.forEach(function(document, j) {
+			async.eachOf(entry.documents, function(document, j, innerCallback) {
 				Model.create(document, function(err) {
 					if (err) {
 						console.error(chalk.red('Error creating document [' + j + '] of ' + entry.model + ' model'));
@@ -136,11 +133,13 @@ Seeder.prototype.populateModels = function(seedData, cb) {
 					} else {
 						console.log('Successfully created document [' + j + '] of ' + entry.model + ' model');
 					}
-					if (++processedEntries == totalEntries) {
-						cb();
-					}
+					innerCallback();
 				});
+			}, function(err) {
+				outerCallback();
 			});
+		}, function(err) {
+			cb();
 		});
 	});
 };


### PR DESCRIPTION
I have noticed that the populateModels callback was invoked without waiting for the entries being added to the database. This was a problem when running seeder from a script that ends immediately after populateModels, as not all the data may have had time to be written into the DB. So I moved the invocation inside the forEach with a check that make sure it is only called when all the entries have been processed.