### PR TITLE
fixed cb error in example code in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ seeder.connect('mongodb://localhost/sample-dev', function() {
 	seeder.clearModels(['Model1', 'Model2'], function() {
 
 		// Callback to populate DB once collections have been cleared
-		seeder.populateModels(data);
+		seeder.populateModels(data, function() {
+			//seeder.disconnect();
+		});
 
 	});
 });


### PR DESCRIPTION
many people are getting the "cb" error when they follow the example code. I fixed that inside the README file, however, I have indicated that the cb function should disconnect the database and I do not think mongoose-seed library provides the proper function to do so. Just something to add in the next version of this library