### PR TITLE
Can now pass connection options to seeder.  Mongoose takes either 2 o…

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function Seeder() {
     this.connected = false;
 }
 
-Seeder.prototype.connect = function(db, cb) {
+Seeder.prototype.connect = function(...params) {
     var _this = this;
     /*
 		switch (mongoose.connection.readyState) {
@@ -24,24 +24,49 @@ Seeder.prototype.connect = function(db, cb) {
 		}
 		source http://mongoosejs.com/docs/api.html#connection_Connection-readyState
 	*/
+
+    var db, cb, opts = null;
+
+    if (params.length == 2) {
+        db = params[0];
+        cb = params[1];
+    } else if (params.length == 3) {
+        db = params[0];
+        opts = params[1]; 
+        cb = params[2]; 
+    } else {
+        console.error('Pass either 2 or 3 arguments to seeder.connect'); 
+        process.exit(1);
+    }
+
     if (mongoose.connection.readyState === 1) {
         _this.connected = true;
         console.log('Successfully initialized mongoose-seed');
         cb();
     } else {
-        mongoose.connect(db, function(err) {
-            // Log Error
-            if (err) {
-                console.error(chalk.red('Could not connect to MongoDB!'));
-                console.log(err);
-            } else {
-                _this.connected = true;
-                console.log('Successfully initialized mongoose-seed');
-                cb();
-            }
-        });
+        if (opts) {
+            mongoose.connect(db, opts, function (err) {
+                afterConnect(_this, err, cb);
+            });
+        } else {
+            mongoose.connect(db, function (err) {
+                afterConnect(_this, err, cb);
+            });
+        }
     }
 };
+
+function afterConnect(_this, err, cb) {
+    // Log Error
+    if (err) {
+        console.error(chalk.red('Could not connect to MongoDB!'));
+        console.log(err);
+    } else {
+        _this.connected = true;
+        console.log('Successfully initialized mongoose-seed');
+        cb();
+    }
+}
 
 Seeder.prototype.loadModels = function(modelPaths) {
     console.log(modelPaths);

--- a/test/teste-mongoose.js
+++ b/test/teste-mongoose.js
@@ -20,6 +20,17 @@ describe('Mongoose-Seeder', function() {
 
     });
 
+    it('passes connection options', function (done) {
+        var connection_options = {
+            reconnectTries: 3,
+            reconnectInterval: 1000
+        };
+        seeder.connect(connection_url, connection_options, function () {
+            expect(mongoose.connection.readyState).to.equal(1);
+            done();
+        });
+    });
+    
     it('Load Models', function(done) {
         seeder.connect(connection_url, function() {
             seeder.loadModels(['test/testModel.js']);


### PR DESCRIPTION
This fix enables the seeder to take connection options.  I had been using the seeder locally but then set up a multi-node MongoDB on a remote server and noticed there was no way for me to pass connection options with mongos.  For example: 

`
mongooseOptions = {
  mongos: {
    poolSize: 5,
    reconnectTries: 1000
  }
}
`

There was no way for me to run seeder against that MongoDB without passing options containing the mongos attribute.  I've tested that my changes work with a multi-node db.  

I also noticed that the Mongoose connect function's TypeScript declaration had both a 2-parameter version and a 3-parameter version.  I'm open to you changing this code any way you see fit to handle the variable number of parameters for the seeder connect function, but it just needs to be able to take options somehow.  I followed your shorthand style (db and cb) and used the variable name opts.  