### PR TITLE
Add disconnect function

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,40 +11,37 @@ var seeder = require('mongoose-seed');
 // Connect to MongoDB via Mongoose
 seeder.connect('mongodb://localhost/sample-dev', function() {
 
-	// Load Mongoose models
-	seeder.loadModels([
-		'app/model1File.js',
-		'app/model2File.js'
-	]);
+  // Load Mongoose models
+  seeder.loadModels([
+    'app/model1File.js',
+    'app/model2File.js'
+  ]);
 
-	// Clear specified collections
-	seeder.clearModels(['Model1', 'Model2'], function() {
+  // Clear specified collections
+  seeder.clearModels(['Model1', 'Model2'], function() {
 
-		// Callback to populate DB once collections have been cleared
-		seeder.populateModels(data, function() {
-			//seeder.disconnect();
-		});
+    // Callback to populate DB once collections have been cleared
+    seeder.populateModels(data, function() {
+      seeder.disconnect();
+    });
 
-	});
+  });
 });
 
 // Data array containing seed data - documents organized by Model
-var data = [
-	{
-		'model': 'Model1',
-		'documents': [
-			{
-				'name': 'Doc1'
-				'value': 200
-			},
-			{
-				'name': 'Doc2'
-				'value': 400
-			}
-		]
-	}
-];
-
+var data = [{
+  'model': 'Model1',
+  'documents': [
+    {
+      'name': 'Doc1'
+      'value': 200
+    },
+    {
+      'name': 'Doc2'
+      'value': 400
+    }
+  ]
+}];
 
 ```
 
@@ -71,3 +68,10 @@ Clears DB collection specified by each model in modelArray.  Callback is execute
 ### seeder.populateModels(dataArray, [callback])
 
 Populates MongoDB with documents in dataArray.  dataArray consists of objects with 'model' and 'documents' keys, where 'documents' is an array of valid collection documents.  Note that Mongoose Schema validation *is* enforced.
+
+---
+
+### seeder.disconnect()
+
+Disconnects mongoose db-handle. Use it inside `populateModels` callback to cleanly exit the program
+(see example above).

--- a/index.js
+++ b/index.js
@@ -175,4 +175,8 @@ Seeder.prototype.populateModels = function(seedData, cb) {
     });
 };
 
+Seeder.prototype.disconnect = function disconnect() {
+  mongoose.disconnect();
+};
+
 module.exports = new Seeder();


### PR DESCRIPTION
Seeder-api to be able to cleanly exit a seed program. Simply calls
mongoose's `disconnect`.