### PR TITLE
Update lodash to 4.17.10

### DIFF
--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ Seeder.prototype.populateModels = function(seedData, cb) {
         return new Error('Not connected to db, exiting function');
     }
 
-    var modelNames = _.unique(_.pluck(seedData, 'model'));
+    var modelNames = _.uniq(_.map(seedData, 'model'));
     var _this = this;
 
     // Confirm that all Models have been registered in Mongoose

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "async": "~1.2.0",
     "chalk": "~1.0.0",
-    "lodash": "~3.9.3",
+    "lodash": "~4.17.10",
     "path": "~0.11.14"
   },
   "devDependencies": {


### PR DESCRIPTION
Reasoning: `npm audit` reports an unsolvable vulnerability when using mongoose-seed because of lodash-3.x.

Needed to update the use of `pluck` and `unique` in favor of `map` and
`uniq` which require no further changes.