### PR TITLE
Connect to return promise.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ var data = [
 
 ## Methods
 
-### seeder.connect(db, [callback])
+### seeder.connect(db, [options], [callback])
 
-Initializes connection to MongoDB via Mongoose singleton.
+Initializes connection to MongoDB via Mongoose singleton.  
+If callback is not supplied, a promise will be returned.
 
 ---------------------------------------
 
@@ -82,3 +83,9 @@ Disconnects mongoose db-handle. Use it inside `populateModels` callback to clean
 ### seeder.setLogOutput(logOutput)
 
 Disables or enables calls to `console.log`. If `false` is passed, only errors will be print to console.
+
+---
+
+### seeder.setPromise(PromiseConstructor)
+
+Changes promise library used by the seeder (and in turn the underlying mongoose library).

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ function consoleLog(_this, message) {
  */
 Seeder.prototype.setPromise = function (promise) {
    this.promise = promise;
+   mongoose.Promise = this.promise;
 };
 
 Seeder.prototype.setLogOutput = function (logOutput) {
@@ -79,7 +80,7 @@ Seeder.prototype.connect = function(database, options = {}, callback = null) {
         afterConnect(_this, error, callback);
       });
     } else {
-      return new Promise(function(resolve, reject) {
+      return new this.promise(function(resolve, reject) {
         if (mongoose.connection.readyState === STATES.Connecting) {
           consoleLog(_this, 'Successfully initialized mongoose-seed');
           return resolve();

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "async": "~1.2.0",
     "chalk": "~1.0.0",
-    "lodash": "~4.17.10",
+    "lodash": "~4.17.11",
     "path": "~0.11.14"
   },
   "devDependencies": {

--- a/test/teste-mongoose.js
+++ b/test/teste-mongoose.js
@@ -120,4 +120,14 @@ describe('Mongoose-Seeder', function() {
 
     });
 
+    it('returns a promise', function() {
+        let promise = seeder.connect(connection_url).catch(function(error) {});
+        expect(promise).to.be.a('promise');
+    });
+
+  it('check mongoose connection after promise', async function() {
+    await seeder.connect(connection_url);
+    expect(mongoose.connection.readyState).to.equal(1);
+  });
+
 });


### PR DESCRIPTION
Pull request contains updates mainly to the `connect` method, no breaking changes. If callback is not included in call to `connect` a `Promise` is created and returned.

A few minor additional adjustments have been made:

* Updated lodash to get rid of a warning from npm audit.
* Added `option.useMongoClient = true`  to get rid of deprecation warning.

I added a `STATES` object which is just a map for the `mongoose.connection.readyState` values (only changed value in the connect code though (for now)) and also changed the in-parameters of the connect method and added JSDocs for it.

This does not fully solve #12, but it's a start.