### PR TITLE
Model Args

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,12 +84,12 @@ function afterConnect(_this, err, cb) {
     }
 }
 
-Seeder.prototype.loadModels = function(modelPaths) {
+Seeder.prototype.loadModels = function(modelPaths, ...modelArgs) {
     consoleLog(this, modelPaths);
     modelPaths.forEach(function(modelPath) {
         var model = require(path.resolve(modelPath));
         if (model instanceof Function) {
-            model();
+            model(...modelArgs);
         }
     });
 };


### PR DESCRIPTION
Added possibility to pass the model function arguments in the case of the model function accepts an argument. Conder the usecase.

Mongoose model definition in [feathers.js](https://feathersjs.com/) and [feathers-mongoose](https://github.com/feathersjs-ecosystem/feathers-mongoose)
```js
module.exports = function(app) {
  const modelName = 'category';
  const mongooseClient = app.get('mongooseClient');
  const schema = new mongooseClient.Schema({
    name: String,
  }, {
    timestamps: true,
  });
  if (mongooseClient.modelNames().includes(modelName)) {
    mongooseClient.deleteModel(modelName);
  }
  return mongooseClient.model(modelName, schema);
};

```

The plugin code, which will actually initiate the seeder
```js
const path = require('path');
const seeder = require('mongoose-seed');
const seedable = require('./seeder/seed');
const logger = require('./logger');

module.exports = function(app) {
    seeder.connect(app.get('mongodb'), function() {

        // requires the app argument to load the model
        seeder.loadModels([
          path.join(__dirname, 'models/category.model.js')
        ], app);

        seeder.clearModels(['category'], function() {
          seeder.populateModels(seedable, function() {
            seeder.disconnect();
          });
        });
    });
  }
};

```