### PR TITLE
Mongoose deprecated options removed

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,9 +50,6 @@ Seeder.prototype.connect = function(...params) {
         process.exit(1);
     }
     
-    mongoose.set("useCreateIndex", true);
-    mongoose.set("useNewUrlParser", true);
-    
     if (mongoose.connection.readyState === 1) {
         _this.connected = true;
         consoleLog(_this, 'Successfully initialized mongoose-seed');


### PR DESCRIPTION
Deprecated options must be removed as per Mongoose advise on link below. These options are now true by default.
https://mongoosejs.com/docs/migrating_to_6.html#no-more-deprecation-warning-options